### PR TITLE
fix array to string conversion in runtime parser

### DIFF
--- a/resources/views/sets/hobbies.antlers.html
+++ b/resources/views/sets/hobbies.antlers.html
@@ -2,6 +2,6 @@
     {{ partial:components.title }}
 
     <p class="mt-6 text-xl font-medium text-gray-600 dark:text-gray-300">
-        {{ hobbies join=", " }}
+        {{ hobbies | join }}
     </p>
 </div>


### PR DESCRIPTION
When you switch to the new antlers runtime parser, you get an error: 
`ErrorException Array to string conversion`

This change fixes it.